### PR TITLE
[updatecli] Update Rust version to 1.79.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,5 @@
-[toolchain]
-channel = "1.77"
-components = ["rustfmt", "clippy"]
-targets = ["wasm32-wasi"]
 
-# Note: rebuilding the wasm requires targets
-# wasm32-unknown-unknown and wasm32-wasi
+[toolchain]
+  channel = "1.79.0"
+  components = ["rustfmt", "clippy"]
+  targets = ["wasm32-wasi"]


### PR DESCRIPTION



<Actions>
    <action id="9a0d57bc93a1e7b9ecd7683bff87e735b9ad61de58a3916b87a0a3424f5c58d6">
        <h3>Update Rust version inside of rust-toolchain file</h3>
        <details id="ca7b0baf84b3984b38c8a5c79b46ed550b2eb8aeba21f49aa2b213a495ca9e08">
            <summary>deps(rust): update Rust version to 1.79.0</summary>
            <p>key &#34;toolchain.channel&#34;, from file &#34;/tmp/updatecli/github/olblak/wapc-rs/rust-toolchain.toml&#34;, is incorrectly set to &#34;1.77&#34; and should be &#34;1.79.0&#34;</p>
            <details>
                <summary>1.79.0</summary>
                <pre>&#xA;Release published on the 2024-06-13 14:04:46 +0000 UTC at the url https://github.com/rust-lang/rust/releases/tag/1.79.0&#xA;&#xA;&lt;a id=&#34;1.79.0-Language&#34;&gt;&lt;/a&gt;&#xA;&#xA;## Language&#xA;&#xA;- [Stabilize inline `const {}` expressions.](https://github.com/rust-lang/rust/pull/104087/)&#xA;- [Prevent opaque types being instantiated twice with different regions within the same function.](https://github.com/rust-lang/rust/pull/116935/)&#xA;- [Stabilize WebAssembly target features that are in phase 4 and 5.](https://github.com/rust-lang/rust/pull/117457/)&#xA;- [Add the `redundant_lifetimes` lint to detect lifetimes which are semantically redundant.](https://github.com/rust-lang/rust/pull/118391/)&#xA;- [Stabilize the `unnameable_types` lint for public types that can&#39;t be named.](https://github.com/rust-lang/rust/pull/120144/)&#xA;- [Enable debuginfo in macros, and stabilize `-C collapse-macro-debuginfo` and `#[collapse_debuginfo]`.](https://github.com/rust-lang/rust/pull/120845/)&#xA;- [Propagate temporary lifetime extension into `if` and `match` expressions.](https://github.com/rust-lang/rust/pull/121346/)&#xA;- [Restrict promotion of `const fn` calls.](https://github.com/rust-lang/rust/pull/121557/)&#xA;- [Warn against refining impls of crate-private traits with `refining_impl_trait` lint.](https://github.com/rust-lang/rust/pull/121720/)&#xA;- [Stabilize associated type bounds (RFC 2289).](https://github.com/rust-lang/rust/pull/122055/)&#xA;- [Stabilize importing `main` from other modules or crates.](https://github.com/rust-lang/rust/pull/122060/)&#xA;- [Check return types of function types for well-formedness](https://github.com/rust-lang/rust/pull/115538)&#xA;- [Rework `impl Trait` lifetime inference](https://github.com/rust-lang/rust/pull/116891/)&#xA;- [Change inductive trait solver cycles to be ambiguous](https://github.com/rust-lang/rust/pull/122791)&#xA;&#xA;&lt;a id=&#34;1.79.0-Compiler&#34;&gt;&lt;/a&gt;&#xA;&#xA;## Compiler&#xA;&#xA;- [Define `-C strip` to only affect binaries, not artifacts like `.pdb`.](https://github.com/rust-lang/rust/pull/115120/)&#xA;- [Stabilize `-Crelro-level` for controlling runtime link hardening.](https://github.com/rust-lang/rust/pull/121694/)&#xA;- [Stabilize checking of `cfg` names and values at compile-time with `--check-cfg`.](https://github.com/rust-lang/rust/pull/123501/) *Note that this only stabilizes the compiler part, the Cargo part is still unstable in this release.*&#xA;- [Add `aarch64-apple-visionos` and `aarch64-apple-visionos-sim` tier 3 targets.](https://github.com/rust-lang/rust/pull/121419/)&#xA;- [Add `riscv32ima-unknown-none-elf` tier 3 target.](https://github.com/rust-lang/rust/pull/122696/)&#xA;- [Promote several Windows targets to tier 2](https://github.com/rust-lang/rust/pull/121712): `aarch64-pc-windows-gnullvm`, `i686-pc-windows-gnullvm`, and `x86_64-pc-windows-gnullvm`.&#xA;&#xA;Refer to Rust&#39;s [platform support page](https://doc.rust-lang.org/nightly/rustc/platform-support.html) for more information on Rust&#39;s tiered platform support.&#xA;&#xA;&lt;a id=&#34;1.79.0-Libraries&#34;&gt;&lt;/a&gt;&#xA;&#xA;## Libraries&#xA;&#xA;- [Implement `FromIterator` for `(impl Default + Extend, impl Default + Extend)`.](https://github.com/rust-lang/rust/pull/107462/)&#xA;- [Implement `{Div,Rem}Assign&lt;NonZero&lt;X&gt;&gt;` on `X`.](https://github.com/rust-lang/rust/pull/121952/)&#xA;- [Document overrides of `clone_from()` in core/std.](https://github.com/rust-lang/rust/pull/122201/)&#xA;- [Link MSVC default lib in core.](https://github.com/rust-lang/rust/pull/122268/)&#xA;- [Caution against using `transmute` between pointers and integers.](https://github.com/rust-lang/rust/pull/122379/)&#xA;- [Enable frame pointers for the standard library.](https://github.com/rust-lang/rust/pull/122646/)&#xA;&#xA;&lt;a id=&#34;1.79.0-Stabilized-APIs&#34;&gt;&lt;/a&gt;&#xA;&#xA;## Stabilized APIs&#xA;&#xA;- [`{integer}::unchecked_add`](https://doc.rust-lang.org/stable/core/primitive.i32.html#method.unchecked_add)&#xA;- [`{integer}::unchecked_mul`](https://doc.rust-lang.org/stable/core/primitive.i32.html#method.unchecked_mul)&#xA;- [`{integer}::unchecked_sub`](https://doc.rust-lang.org/stable/core/primitive.i32.html#method.unchecked_sub)&#xA;- [`&lt;[T]&gt;::split_at_unchecked`](https://doc.rust-lang.org/stable/core/primitive.slice.html#method.split_at_unchecked)&#xA;- [`&lt;[T]&gt;::split_at_mut_unchecked`](https://doc.rust-lang.org/stable/core/primitive.slice.html#method.split_at_mut_unchecked)&#xA;- [`&lt;[u8]&gt;::utf8_chunks`](https://doc.rust-lang.org/stable/core/primitive.slice.html#method.utf8_chunks)&#xA;- [`str::Utf8Chunks`](https://doc.rust-lang.org/stable/core/str/struct.Utf8Chunks.html)&#xA;- [`str::Utf8Chunk`](https://doc.rust-lang.org/stable/core/str/struct.Utf8Chunk.html)&#xA;- [`&lt;*const T&gt;::is_aligned`](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.is_aligned)&#xA;- [`&lt;*mut T&gt;::is_aligned`](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.is_aligned-1)&#xA;- [`NonNull::is_aligned`](https://doc.rust-lang.org/stable/core/ptr/struct.NonNull.html#method.is_aligned)&#xA;- [`&lt;*const [T]&gt;::len`](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.len)&#xA;- [`&lt;*mut [T]&gt;::len`](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.len-1)&#xA;- [`&lt;*const [T]&gt;::is_empty`](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.is_empty)&#xA;- [`&lt;*mut [T]&gt;::is_empty`](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.is_empty-1)&#xA;- [`NonNull::&lt;[T]&gt;::is_empty`](https://doc.rust-lang.org/stable/core/ptr/struct.NonNull.html#method.is_empty)&#xA;- [`CStr::count_bytes`](https://doc.rust-lang.org/stable/core/ffi/c_str/struct.CStr.html#method.count_bytes)&#xA;- [`io::Error::downcast`](https://doc.rust-lang.org/stable/std/io/struct.Error.html#method.downcast)&#xA;- [`num::NonZero&lt;T&gt;`](https://doc.rust-lang.org/stable/core/num/struct.NonZero.html)&#xA;- [`path::absolute`](https://doc.rust-lang.org/stable/std/path/fn.absolute.html)&#xA;- [`proc_macro::Literal::byte_character`](https://doc.rust-lang.org/stable/proc_macro/struct.Literal.html#method.byte_character)&#xA;- [`proc_macro::Literal::c_string`](https://doc.rust-lang.org/stable/proc_macro/struct.Literal.html#method.c_string)&#xA;&#xA;These APIs are now stable in const contexts:&#xA;&#xA;- [`Atomic*::into_inner`](https://doc.rust-lang.org/stable/core/sync/atomic/struct.AtomicUsize.html#method.into_inner)&#xA;- [`io::Cursor::new`](https://doc.rust-lang.org/stable/std/io/struct.Cursor.html#method.new)&#xA;- [`io::Cursor::get_ref`](https://doc.rust-lang.org/stable/std/io/struct.Cursor.html#method.get_ref)&#xA;- [`io::Cursor::position`](https://doc.rust-lang.org/stable/std/io/struct.Cursor.html#method.position)&#xA;- [`io::empty`](https://doc.rust-lang.org/stable/std/io/fn.empty.html)&#xA;- [`io::repeat`](https://doc.rust-lang.org/stable/std/io/fn.repeat.html)&#xA;- [`io::sink`](https://doc.rust-lang.org/stable/std/io/fn.sink.html)&#xA;- [`panic::Location::caller`](https://doc.rust-lang.org/stable/std/panic/struct.Location.html#method.caller)&#xA;- [`panic::Location::file`](https://doc.rust-lang.org/stable/std/panic/struct.Location.html#method.file)&#xA;- [`panic::Location::line`](https://doc.rust-lang.org/stable/std/panic/struct.Location.html#method.line)&#xA;- [`panic::Location::column`](https://doc.rust-lang.org/stable/std/panic/struct.Location.html#method.column)&#xA;&#xA;&lt;a id=&#34;1.79.0-Cargo&#34;&gt;&lt;/a&gt;&#xA;&#xA;## Cargo&#xA;&#xA;- [Prevent dashes in `lib.name`, always normalizing to `_`.](https://github.com/rust-lang/cargo/pull/12783/)&#xA;- [Stabilize MSRV-aware version requirement selection in `cargo add`.](https://github.com/rust-lang/cargo/pull/13608/)&#xA;- [Switch to using `gitoxide` by default for listing files.](https://github.com/rust-lang/cargo/pull/13696/)&#xA;&#xA;&lt;a id=&#34;1.79.0-Rustdoc&#34;&gt;&lt;/a&gt;&#xA;&#xA;## Rustdoc&#xA;&#xA;- [Always display stability version even if it&#39;s the same as the containing item.](https://github.com/rust-lang/rust/pull/118441/)&#xA;- [Show a single search result for items with multiple paths.](https://github.com/rust-lang/rust/pull/119912/)&#xA;- [Support typing `/` in docs to begin a search.](https://github.com/rust-lang/rust/pull/123355/)&#xA;&#xA;&lt;a id=&#34;1.79.0-Misc&#34;&gt;&lt;/a&gt;&#xA;&#xA;## Misc&#xA;&#xA;&lt;a id=&#34;1.79.0-Compatibility-Notes&#34;&gt;&lt;/a&gt;&#xA;&#xA;## Compatibility Notes&#xA;&#xA;- [Update the minimum external LLVM to 17.](https://github.com/rust-lang/rust/pull/122649/)&#xA;- [`RustcEncodable` and `RustcDecodable` are soft-destabilized, to be removed from the prelude in next edition.](https://github.com/rust-lang/rust/pull/116016/)&#xA;- [The `wasm_c_abi` future-incompatibility lint will warn about use of the non-spec-compliant C ABI.](https://github.com/rust-lang/rust/pull/117918/) Use `wasm-bindgen v0.2.88` to generate forward-compatible bindings.&#xA;- [Check return types of function types for well-formedness](https://github.com/rust-lang/rust/pull/115538)&#xA;</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

